### PR TITLE
Remove autocloseable

### DIFF
--- a/core/src/main/java/com/softwaremill/jox/CloseableChannel.java
+++ b/core/src/main/java/com/softwaremill/jox/CloseableChannel.java
@@ -14,7 +14,7 @@ package com.softwaremill.jox;
  * <p>
  * Closing the channel is thread-safe.
  */
-public interface CloseableChannel extends AutoCloseable {
+public interface CloseableChannel {
     /**
      * Close the channel, indicating that no more elements will be sent.
      * <p>
@@ -39,15 +39,6 @@ public interface CloseableChannel extends AutoCloseable {
      * @return Either {@code null}, or {@link ChannelClosed}, when the channel is already closed.
      */
     Object doneSafe();
-
-    /**
-     * Same as {@link #done()}: close the channel, indicating that no more elements will be sent.
-     * <p>
-     * Enables using channel in {@code try-with-resources} blocks.
-     */
-    default void close() {
-        done();
-    }
 
     //
 

--- a/core/src/main/java/com/softwaremill/jox/CollectSource.java
+++ b/core/src/main/java/com/softwaremill/jox/CollectSource.java
@@ -118,11 +118,6 @@ public class CollectSource<V, T> implements Source<T> {
     }
 
     @Override
-    public void close() {
-        original.close();
-    }
-
-    @Override
     public void error(Throwable reason) {
         original.error(reason);
     }


### PR DESCRIPTION
It doesn't fit the target model of using channels (using structured concurrency)