### PR TITLE
Move the scoped value determining the channel buffer size from Channel to Flow

### DIFF
--- a/channels/src/main/java/com/softwaremill/jox/Channel.java
+++ b/channels/src/main/java/com/softwaremill/jox/Channel.java
@@ -87,11 +87,6 @@ public final class Channel<T> implements Source<T>, Sink<T> {
       operations won't use them, so the relinking won't be useful.
      */
 
-    /**
-     * Can be used with {@link Channel#withScopedBufferSize()} to pass buffer size value from scope.
-     * e.g. `ScopedValues.where(BUFFER_SIZE, 8).run(() -> Channel.withScopedBufferSize())` will create a channel with buffer size = 8
-     **/
-    public static final ScopedValue<Integer> BUFFER_SIZE = ScopedValue.newInstance();
     public static final int DEFAULT_BUFFER_SIZE = 16;
 
     // immutable state
@@ -215,13 +210,6 @@ public final class Channel<T> implements Source<T>, Sink<T> {
 
     public static <T> Channel<T> newUnlimitedChannel() {
         return new Channel<>(UNLIMITED_CAPACITY);
-    }
-
-    /**
-     * Allows for creating Channel with buffer size specified in scope by {@link ScopedValue} {@link Channel#BUFFER_SIZE}
-     */
-    public static <T> Channel<T> withScopedBufferSize() {
-        return new Channel<>(BUFFER_SIZE.orElse(DEFAULT_BUFFER_SIZE));
     }
 
     private static final int UNLIMITED_CAPACITY = -1;

--- a/flows/src/main/java/com/softwaremill/jox/flows/Flows.java
+++ b/flows/src/main/java/com/softwaremill/jox/flows/Flows.java
@@ -302,7 +302,7 @@ public final class Flows {
      * Creates a Flow from a Publisher, that is, which emits the elements received by subscribing to the publisher. A new
      * subscription is created every time this flow is run.
      * <p>
-     * The data is passed from a subscription to the flow using a Channel, with a capacity given by the {@link Channel#BUFFER_SIZE} in
+     * The data is passed from a subscription to the flow using a Channel, with a capacity given by the {@link Flow#CHANNEL_BUFFER_SIZE} in
      * scope or {@link Channel#DEFAULT_BUFFER_SIZE} is used. That's also how many elements will be at most requested from the publisher at a time.
      * <p>
      * The publisher parameter should implement the JDK 9+ Flow.Publisher API
@@ -311,8 +311,8 @@ public final class Flows {
         return usingEmit(emit -> {
             // using an unsafe scope for efficiency
             Scopes.unsupervised(scope -> {
-                Channel<T> channel = Channel.withScopedBufferSize();
-                int capacity = Channel.BUFFER_SIZE.orElse(Channel.DEFAULT_BUFFER_SIZE);
+                Channel<T> channel = Flow.newChannelWithBufferSizeFromScope();
+                int capacity = Flow.CHANNEL_BUFFER_SIZE.orElse(Channel.DEFAULT_BUFFER_SIZE);
                 int demandThreshold = (int) Math.ceil(capacity / 2.0);
 
                 // used to "extract" the subscription that is set in the subscription running in a fork
@@ -398,7 +398,7 @@ public final class Flows {
      * is completed immediately, otherwise the interleaving continues with the remaining non-completed flows. Once all but one flows are
      * complete, the elements of the remaining non-complete flow are emitted by the returned flow.
      * <p>
-     * The provided flows are run concurrently and asynchronously. The size of used buffer is determined by the {@link Channel#BUFFER_SIZE} that is in scope, or default {@link Channel#DEFAULT_BUFFER_SIZE} is used.
+     * The provided flows are run concurrently and asynchronously. The size of used buffer is determined by the {@link Flow#CHANNEL_BUFFER_SIZE} that is in scope, or default {@link Channel#DEFAULT_BUFFER_SIZE} is used.
      *
      * @param flows         The flows whose elements will be interleaved.
      * @param segmentSize   The number of elements sent from each flow before switching to the next one.
@@ -406,7 +406,7 @@ public final class Flows {
      *                      remaining non-completed flows.
      */
     public static <T> Flow<T> interleaveAll(List<Flow<T>> flows, int segmentSize, boolean eagerComplete) {
-        return interleaveAll(flows, segmentSize, eagerComplete, Channel.BUFFER_SIZE.orElse(Channel.DEFAULT_BUFFER_SIZE));
+        return interleaveAll(flows, segmentSize, eagerComplete, Flow.CHANNEL_BUFFER_SIZE.orElse(Channel.DEFAULT_BUFFER_SIZE));
     }
 
     /**

--- a/flows/src/main/java/com/softwaremill/jox/flows/FromFlowPublisher.java
+++ b/flows/src/main/java/com/softwaremill/jox/flows/FromFlowPublisher.java
@@ -65,7 +65,7 @@ class FromFlowPublisher<T> implements Flow.Publisher<T> {
                 // we need separate error & data channels so that we can select from error & signals only, without receiving data
                 // 1.4 any errors from running the flow end up here
                 Channel<DummyError> errors = Channel.newUnlimitedChannel();
-                Channel<T> data = Channel.withScopedBufferSize();
+                Channel<T> data = com.softwaremill.jox.flows.Flow.newChannelWithBufferSizeFromScope();
 
                 // running the flow in the background; all errors end up as an error of the `errors` channel
                 forkPropagate(scope, errors, () -> {

--- a/flows/src/main/java/com/softwaremill/jox/flows/GroupByImpl.java
+++ b/flows/src/main/java/com/softwaremill/jox/flows/GroupByImpl.java
@@ -137,7 +137,7 @@ class GroupByImpl<T, V, U> {
                 // Channel where all elements emitted by child flows will be sent; we use such a collective channel instead of
                 // enumerating all child channels in the main `select`, as `select`s don't scale well with the number of
                 // clauses. The elements from this channel are then emitted by the returned flow.
-                Channel<U> childOutput = Channel.withScopedBufferSize();
+                Channel<U> childOutput = Flow.newChannelWithBufferSizeFromScope();
 
                 // Channel where completion of children is signalled (because the parent is complete, or the parallelism limit
                 // is reached).
@@ -227,7 +227,7 @@ class GroupByImpl<T, V, U> {
             // Starting a new child flow, running in the background; the child flow receives values via a channel,
             // and feeds its output to `childOutput`. Done signals are forwarded to `childDone`; elements & errors
             // are propagated to `childOutput`.
-            Channel<T> childChannel = Channel.withScopedBufferSize();
+            Channel<T> childChannel = Flow.newChannelWithBufferSizeFromScope();
             s = s.withChildAdded(v, childChannel);
 
             scope.forkUnsupervised(() -> {

--- a/flows/src/test/java/com/softwaremill/jox/flows/FlowGroupedTest.java
+++ b/flows/src/test/java/com/softwaremill/jox/flows/FlowGroupedTest.java
@@ -266,7 +266,7 @@ public class FlowGroupedTest {
     void groupedWeightedWithin_shouldGroupElementsOnTimeoutInFirstBatchAndConsiderMaxWeightInRemainingBatches() throws InterruptedException {
         Scopes.supervised(scope -> {
             // given
-            var c = Channel.<Integer>withScopedBufferSize();
+            var c = Flow.<Integer>newChannelWithBufferSizeFromScope();
             scope.fork(() -> {
                 c.send(1);
                 c.send(2);

--- a/flows/src/test/java/com/softwaremill/jox/flows/FlowInterleaveTest.java
+++ b/flows/src/test/java/com/softwaremill/jox/flows/FlowInterleaveTest.java
@@ -73,7 +73,7 @@ public class FlowInterleaveTest {
         var c2 = Flows.fromValues(2, 4, 6, 8, 10, 12);
 
         // when
-        var result = ScopedValue.where(Channel.BUFFER_SIZE, 10)
+        var result = ScopedValue.where(Flow.CHANNEL_BUFFER_SIZE, 10)
                 .call(() -> c1.interleave(c2, 1, false).runToList());
 
         // then

--- a/flows/src/test/java/com/softwaremill/jox/flows/FlowRunOperationsTest.java
+++ b/flows/src/test/java/com/softwaremill/jox/flows/FlowRunOperationsTest.java
@@ -75,7 +75,7 @@ public class FlowRunOperationsTest {
 
     @Test
     void runToChannel_shouldRunWithBufferSizeDefinedInScope() throws Throwable {
-        ScopedValue.where(Channel.BUFFER_SIZE, 2).call(() -> {
+        ScopedValue.where(Flow.CHANNEL_BUFFER_SIZE, 2).call(() -> {
             Scopes.unsupervised(scope -> {
                 // given
                 Flow<Integer> flow = Flows.fromValues(1, 2, 3);

--- a/structured/src/main/java/com/softwaremill/jox/structured/ActorRef.java
+++ b/structured/src/main/java/com/softwaremill/jox/structured/ActorRef.java
@@ -74,10 +74,10 @@ public class ActorRef<T> {
      * propagated to the caller, and the actor continues. Fatal exceptions, or exceptions that occur during `ActorRef.tell` invocations,
      * cause the actor's channel to be closed with an error, and are propagated to the enclosing scope.
      * <p>
-     * The actor's mailbox (incoming channel) will have a capacity as specified by the {@link Channel#BUFFER_SIZE} in scope or {@link Channel#DEFAULT_BUFFER_SIZE} is used.
+     * The actor's mailbox (incoming channel) will have a capacity of {@link Channel#DEFAULT_BUFFER_SIZE}.
      */
     public static <T> ActorRef<T> create(Scope scope, T logic, Consumer<T> close) {
-        Channel<ThrowingConsumer<T>> c = Channel.withScopedBufferSize();
+        Channel<ThrowingConsumer<T>> c = Channel.newBufferedDefaultChannel();
         ActorRef<T> ref = new ActorRef<>(c);
         scope.fork(() -> {
             try {


### PR DESCRIPTION
That way `Channel` can be used by any Java version, while `Flow` - only with 21 (as it uses preview features).