### PR TITLE
Bump golang to 1.24.3

### DIFF
--- a/bench/bench-go/go.mod
+++ b/bench/bench-go/go.mod
@@ -1,3 +1,3 @@
 module bench
 
-go 1.22.0
+go 1.24.3


### PR DESCRIPTION
This should silence vulnerabilities reported by our scanner.