### PR TITLE
fix Flow.take waiting for n+1 elements instead of terminating at n

### DIFF
--- a/flows/src/test/java/com/softwaremill/jox/flows/FlowTest.java
+++ b/flows/src/test/java/com/softwaremill/jox/flows/FlowTest.java
@@ -1,20 +1,21 @@
 package com.softwaremill.jox.flows;
 
-import static com.softwaremill.jox.structured.Scopes.supervised;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.junit.jupiter.api.Assertions.*;
+import com.softwaremill.jox.Channel;
+import com.softwaremill.jox.ChannelError;
+import com.softwaremill.jox.Source;
+import com.softwaremill.jox.structured.JoxScopeExecutionException;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
-import org.junit.jupiter.api.Test;
-
-import com.softwaremill.jox.ChannelError;
-import com.softwaremill.jox.Source;
-import com.softwaremill.jox.structured.JoxScopeExecutionException;
+import static com.softwaremill.jox.structured.Scopes.supervised;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.jupiter.api.Assertions.*;
 
 class FlowTest {
 
@@ -45,12 +46,10 @@ class FlowTest {
 
     @Test
     void shouldThrowExceptionForFailedFlow() {
-        assertThrows(
-                IllegalStateException.class,
-                () -> {
-                    Flows.failed(new IllegalStateException())
-                            .runFold(0, (acc, n) -> Integer.valueOf(acc.toString() + n));
-                });
+        assertThrows(IllegalStateException.class, () -> {
+            Flows.failed(new IllegalStateException())
+                .runFold(0, (acc, n) -> Integer.valueOf(acc.toString() + n));
+        });
     }
 
     @Test
@@ -99,6 +98,52 @@ class FlowTest {
         Flow<Integer> f = Flows.fromValues(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
         List<Integer> result = f.take(50).runToList();
         assertEquals(List.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), result);
+    }
+
+    @Test
+    void shouldTakeExactlyAllElementsFromFlowWithoutWaitingForMore() throws Exception {
+        supervised(scope -> {
+            var ch = Channel.<Integer>newUnlimitedChannel();
+
+            scope.fork(() -> {
+                ch.send(1);
+                ch.send(2);
+                ch.send(3);
+                return null;
+            });
+
+            var result = Flows.fromSource(ch).take(3).runToList();
+            assertEquals(List.of(1, 2, 3), result);
+            return null;
+        });
+    }
+
+    @Test
+    void shouldBreakImmediatelyAfterTakingNElements() throws Exception {
+        supervised(scope -> {
+            var ch = Channel.<Integer>newUnlimitedChannel();
+            var processedCount = new AtomicInteger(0);
+
+            scope.fork(() -> {
+                for (int i = 1; i <= 10; i++) {
+                    ch.send(i);
+                }
+                return null;
+            });
+
+            var result = Flows.fromSource(ch)
+                .map(
+                    x -> {
+                        processedCount.incrementAndGet();
+                        return x;
+                    })
+                .take(3)
+                .runToList();
+
+            assertEquals(List.of(1, 2, 3), result);
+            assertEquals(3, processedCount.get());
+            return null;
+        });
     }
 
     @Test


### PR DESCRIPTION
Previously, `take(n)` would hang forever if the source had exactly n elements. This happened because it tried to read one more element (to check if it should break) even after taking all n elements it needed.

For example, `take(3)` on a 3-element stream would:
1. Take element 1
2. Take element 2 
3. Take element 3
4. Try to read element 4... and wait forever

Now it breaks right after taking the n-th element, without trying to read more:

Added test `shouldBreakImmediatelyAfterTakingNElements()` that verifies we process exactly 3 elements when calling `take(3)`, not 4.