### PR TITLE
fix: Skip release-drafter on pull_request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Test
         run: mvn --batch-mode --update-snapshots verify
       - name: Prepare release notes
+        if: github.event_name == 'push'
         uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97 # v6, specifically v6.1.0
         with:
           config-name: release-drafter.yml


### PR DESCRIPTION
## Summary

Release-drafter fails with `Validation Failed: {"resource":"Release","code":"invalid","field":"target_commitish"}` when triggered by `pull_request` events. This happens because in the PR context, the git ref is a temporary merge commit (`refs/pull/N/merge`), which the GitHub API rejects as an invalid `target_commitish` for a release.

Fix: add `if: github.event_name == 'push'` to the "Prepare release notes" step so it only runs on pushes to `main` / tags, where the ref points to a real branch.